### PR TITLE
Add function to check minimum python version 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Swarm64 DA and native PostgreSQL.
 
 - Python min. 3.6 and pip3
 - For TPC-DS only: Linux package `recode`
-- Install additional packages with `pip3 install -r requirements.txt`
+- Install additional packages, for Python 3.6 eg. with: `/usr/bin/python3.6 -m pip install -r requirements.txt`
 - For loading the data, the database must be accessible with the user
   `postgres` *without password*
 

--- a/schemas/ssb/loader.sh
+++ b/schemas/ssb/loader.sh
@@ -5,7 +5,9 @@ cd ../../
 
 source ./scripts/functions.sh
 
-./prepare_benchmark \
+check_and_set_python
+
+${PYTHON} prepare_benchmark \
     --dsn=postgresql://postgres@${DB_HOST}:${DB_PORT}/${DB} \
     --scale-factor=${SCALE_FACTOR} \
     --schema=${SCHEMA} \

--- a/schemas/tpcds/loader.sh
+++ b/schemas/tpcds/loader.sh
@@ -5,7 +5,9 @@ cd ../../
 
 source ./scripts/functions.sh
 
-./prepare_benchmark \
+check_and_set_python
+
+${PYTHON} prepare_benchmark \
     --dsn=postgresql://postgres@${DB_HOST}:${DB_PORT}/${DB} \
     --scale-factor=${SCALE_FACTOR} \
     --schema=${SCHEMA} \

--- a/schemas/tpch/loader.sh
+++ b/schemas/tpch/loader.sh
@@ -5,7 +5,9 @@ cd ../../
 
 source ./scripts/functions.sh
 
-./prepare_benchmark \
+check_and_set_python
+
+${PYTHON} prepare_benchmark \
     --dsn=postgresql://postgres@${DB_HOST}:${DB_PORT}/${DB} \
     --scale-factor=${SCALE_FACTOR} \
     --schema=${SCHEMA} \

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -17,6 +17,7 @@ DB_PORT=5432
 NUM_PARTITIONS=32
 CHUNKS=10
 MAX_JOBS=8
+PYTHON="python3"
 
 function print_help {
 echo "
@@ -114,6 +115,23 @@ function check_and_fail {
 check_and_fail DB "--dbname"
 check_and_fail SCHEMA "--schema"
 check_and_fail SCALE_FACTOR "--scale-factor"
+
+function check_and_set_python {
+    python_minor=$(python3 -c 'import sys; print(sys.version_info[1])')
+    bin_path="/usr/bin"
+
+    if [ $python_minor -lt 6 ]; then
+        echo "${bin_path}/python3 points to a non-supported version. Python >= 3.6 is required."
+        echo "Will try to use python3.6 directly."
+        if [ -f ${bin_path}/python3.6 ]; then
+            echo "Found ${bin_path}/python3.6"
+            PYTHON="python3.6"
+        else
+            echo "Could not find ${bin_path}/python3.6 - Exit"
+            exit 1
+        fi
+    fi
+}
 
 function check_program_and_fail {
     PROGRAM=$1


### PR DESCRIPTION
Add function to check minimum python version 3.6 linked by /usr/bin/python3, or otherwise force it to 3.6

Forcibly using python3.6 across the bench is not an option in order to not exclude users with only python > 3.6