### PR TITLE
auto-analyze: add verbose, disable buffers

### DIFF
--- a/s64da_benchmark_toolkit/db.py
+++ b/s64da_benchmark_toolkit/db.py
@@ -79,7 +79,8 @@ class DB:
         auto_explain_config = {
             'auto_explain.log_min_duration': 500,
             'auto_explain.log_analyze': 'on',
-            'auto_explain.log_buffers': 'on',
+            'auto_explain.log_verbose': 'on',
+            'auto_explain.log_buffers': 'off',
             'auto_explain.log_format': 'json',
             'client_min_messages': 'LOG'
         }


### PR DESCRIPTION
- buffers slow down the queries, so don't do that as we don't use it anyway
- verbose is useful when we start using the columnstore.