### PR TITLE
reduce output

### DIFF
--- a/benchmarks/tpch/prepare.py
+++ b/benchmarks/tpch/prepare.py
@@ -56,7 +56,7 @@ class PrepareBenchmark(PrepareBenchmarkFactory):
         psql_copy = self.psql_exec_cmd(f"COPY {table} FROM STDIN WITH DELIMITER '|'")
 
         if use_chunks:
-            return [f'{dbgen_cmd} -S {chunk} -C {self.args.chunks} | {psql_copy}' for
+            return [f'{dbgen_cmd} -S {chunk} -C {self.args.chunks} 2>/dev/null | {psql_copy}' for
                     chunk in range(1, self.args.chunks + 1)]
 
-        return [f'{dbgen_cmd} | {psql_copy}']
+        return [f'{dbgen_cmd} 2>/dev/null | {psql_copy}']

--- a/s64da_benchmark_toolkit/prepare.py
+++ b/s64da_benchmark_toolkit/prepare.py
@@ -92,10 +92,10 @@ class PrepareBenchmarkFactory:
     def psql_exec_cmd(self, sql):
         return f'psql {self.args.dsn} -c "{sql}"'
 
-    def _run_shell_task(self, task, return_output=False):
+    def _run_shell_task(self, task):
         if not self.cancel_event.is_set():
             p = Popen(task, cwd=self.benchmark.base_dir, shell=True, executable='/bin/bash',
-                      stdout=PIPE if return_output else None)
+                      stdout=PIPE)
             p.wait()
             if(p.returncode != 0):
                 self.cancel_event.set()


### PR DESCRIPTION
trial 2 ;)
- return_output is never used anyway so i think it can be removed
- reduce the output by piping the stdout (not stderr) always so we only see it if we get an error and someone wants it. the psql client anyway tells you what went wrong in the error message on stderr