### PR TITLE
Create results dir if it does not exist

### DIFF
--- a/s64da_benchmark_toolkit/reporting.py
+++ b/s64da_benchmark_toolkit/reporting.py
@@ -55,7 +55,7 @@ class Reporting:
         self.html_output = os.path.join(self.results_root_dir, 'report.html')
         self.query_results = os.path.join(self.results_root_dir, 'query_results')
         self.explain_analyze_dir = os.path.join(self.results_root_dir, 'query_plans')
-        self.prepare_metrics_path = 'prepare_metrics.csv'
+        self.prepare_metrics_filename = 'prepare_metrics.csv'
         self.check_correctness = args.check_correctness
         self.scale_factor = args.scale_factor
         self.explain_analyze = args.explain_analyze
@@ -78,7 +78,7 @@ class Reporting:
 
     def run_report(self, reporting_queue):
         self.df = pandas.DataFrame(columns=QueryMetric.dataframe_columns)
-        if os.path.exists(self.prepare_metrics_path):
+        if os.path.exists(self.prepare_metrics_filename):
             self._save_prepare_metrics()
 
         while not reporting_queue.empty():
@@ -125,7 +125,7 @@ class Reporting:
     def _save_prepare_metrics(self):
         if not os.path.exists(self.results_root_dir):
             os.mkdir(self.results_root_dir) 
-        copyfile(self.prepare_metrics_path, os.path.join(self.results_root_dir, self.prepare_metrics_path))
+        copyfile(self.prepare_metrics_filename, os.path.join(self.results_root_dir, self.prepare_metrics_filename))
 
     def _save_query_output(self, query_metric):
         query_result = query_metric.result

--- a/s64da_benchmark_toolkit/reporting.py
+++ b/s64da_benchmark_toolkit/reporting.py
@@ -78,7 +78,8 @@ class Reporting:
 
     def run_report(self, reporting_queue):
         self.df = pandas.DataFrame(columns=QueryMetric.dataframe_columns)
-        self._save_prepare_metrics()
+        if os.path.exists(self.prepare_metrics_path):
+            self._save_prepare_metrics()
 
         while not reporting_queue.empty():
             query_metric = reporting_queue.get()
@@ -122,8 +123,9 @@ class Reporting:
             plan_file.write(query_metric.plan)
 
     def _save_prepare_metrics(self):
-        if os.path.exists(self.prepare_metrics_path):
-            copyfile(self.prepare_metrics_path, os.path.join(self.results_root_dir, self.prepare_metrics_path))
+        if not os.path.exists(self.results_root_dir):
+            os.mkdir(self.results_root_dir) 
+        copyfile(self.prepare_metrics_path, os.path.join(self.results_root_dir, self.prepare_metrics_path))
 
     def _save_query_output(self, query_metric):
         query_result = query_metric.result


### PR DESCRIPTION
Running a benchmark will fail when executed with only required arguments with:

copyfile(self.prepare_metrics_path, os.path.join(self.results_root_dir, self.prepare_metrics_path))
  File "/usr/lib64/python3.6/shutil.py", line 121, in copyfile
    with open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: 'results/prepare_metrics.csv'

This is due the results directory that does not exist. 