### PR TITLE
Summary timing to show correct result

### DIFF
--- a/s64da_benchmark_toolkit/reporting.py
+++ b/s64da_benchmark_toolkit/reporting.py
@@ -104,11 +104,12 @@ class Reporting:
             if self.check_correctness and self.scale_factor:
                 self._check_correctness()
 
-            total_runtime = self.df['timestamp_stop'].max() - self.df['timestamp_start'].min()
+            sub_df = self.df[self.df['status'] != 'IGNORED']
+            total_runtime = sub_df['timestamp_stop'].max() - sub_df['timestamp_start'].min()
             self.total_runtime_seconds = total_runtime.total_seconds()
             self._print_results()
 
-            print(f'\nTotal runtime: {total_runtime} ({self.total_runtime_seconds:.2f}s)')
+            print(f'\nTotal runtime (OK + ERR): {total_runtime} ({self.total_runtime_seconds:.2f}s)')
         else:
             LOG.warning("The reporting queue was found empty, which indicates that no queries were ran")
 


### PR DESCRIPTION
This fixes the display of the timing summary when there are queries with `IGNORED` status.