### PR TITLE
Load helper functions always before loading the (partitioned) schema

### DIFF
--- a/s64da_benchmark_toolkit/prepare.py
+++ b/s64da_benchmark_toolkit/prepare.py
@@ -308,11 +308,10 @@ class PrepareBenchmarkFactory:
             applied_schema_file.write(applied_schema)
 
         with DBConn(self.args.dsn) as conn:
-            if self.num_partitions:
-                print('Adding helper functions.')
-                common_file_path = os.path.join(s64_benchmark_toolkit_root_dir, 'benchmarks', 'common', 'functions.sql')
-                with open(common_file_path, 'r') as common_sql:
-                    conn.cursor.execute(common_sql.read())
+            print('Adding helper functions.')
+            common_file_path = os.path.join(s64_benchmark_toolkit_root_dir, 'benchmarks', 'common', 'functions.sql')
+            with open(common_file_path, 'r') as common_sql:
+                conn.cursor.execute(common_sql.read())
 
             self._load_pre_schema(conn)
 


### PR DESCRIPTION
The purpose of this PR is to always load the helper function for the partitions. This inclusion of this function is not going to slow down the benchmarks. What we gain is the ability to load partitioned schemas with hard-coded number of partitions without any further changes.