### PR TITLE
Support server-side cursors for running queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Start a benchmark:
     ./run_benchmark \
         --dsn postgresql://postgres@localhost/<target-db> \
         [--benchmark] <tpch|tpcds|ssb|htap> \
-	--use-server-side-cursors
         <optional benchmark-specific arguments>
 
 This runs the benchmark with the default runtime restriction per query.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Start a benchmark:
     ./run_benchmark \
         --dsn postgresql://postgres@localhost/<target-db> \
         [--benchmark] <tpch|tpcds|ssb|htap> \
+	--use-server-side-cursors
         <optional benchmark-specific arguments>
 
 This runs the benchmark with the default runtime restriction per query.
@@ -105,6 +106,10 @@ Note: if you enable correctness checks with the `--check-correctness` flag, the
 parameter `--scale-factor` is required.
 
 ## Optional Parameters
+
+Parameter                 | Description
+--------------------------|-------------------------------------
+`use-server-side-cursors` | Use server-side cursors for executing the queries.
 
 The optional parameters differ by benchmark.
 The ones for TPC-H, TPC-DS, and SSB are described in this section.

--- a/run_benchmark
+++ b/run_benchmark
@@ -103,6 +103,10 @@ def parse_arguments(argv, benchmarks):
         'Supply with DB, e.g. postgresql://postgres@localhost/dbname'
     ))
 
+    common_parser.add_argument('--use-server-side-cursors', default=False, action='store_true',
+        required=False, help=('Use server-side cursors for executing the queries')
+    )
+
     subparsers = common_parser.add_subparsers(dest='benchmark')
     add_streams_parsers(subparsers, benchmarks)
     htap.add_parser(subparsers)

--- a/s64da_benchmark_toolkit/dbconn.py
+++ b/s64da_benchmark_toolkit/dbconn.py
@@ -13,6 +13,7 @@ class DBConn:
         self.dsn = dsn
         self.conn = None
         self.cursor = None
+        self.server_side_cursor = None
         self.statement_timeout = statement_timeout
         self.num_retries = num_retries
         self.retry_wait = retry_wait
@@ -25,6 +26,7 @@ class DBConn:
                 self.conn = psycopg2.connect(self.dsn, options=options)
                 self.conn.autocommit = True
                 self.cursor = self.conn.cursor()
+                self.server_side_cursor = self.conn.cursor('server-side-cursor')
                 break
 
             except psycopg2.Error as exc:
@@ -34,6 +36,7 @@ class DBConn:
 
         assert self.conn, 'There is no connection.'
         assert self.cursor, 'There is no cursor.'
+        assert self.server_side_cursor, 'There is no server-side cursor.'
 
         return self
 

--- a/s64da_benchmark_toolkit/streams.py
+++ b/s64da_benchmark_toolkit/streams.py
@@ -49,6 +49,7 @@ class Streams:
         self.scale_factor = args.scale_factor
         self.query_dir = self._get_query_dir()
         self.explain_analyze = args.explain_analyze
+        self.use_server_side_cursors = args.use_server_side_cursors
         self.reporting = Reporting(benchmark, args, self.config)
 
     @staticmethod
@@ -127,7 +128,7 @@ class Streams:
         query_sql = Streams.apply_sql_modifications(query_sql, (
             ('revenue0', f'revenue{stream_id}'),))
         timeout = self.config.get('timeout', 0)
-        return self.db.run_query(query_sql, timeout, self.explain_analyze)
+        return self.db.run_query(query_sql, timeout, self.explain_analyze, self.use_server_side_cursors)
 
     def _run_stream(self, reporting_queue, stream_id):
         sequence = self.get_stream_sequence(stream_id)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -16,6 +16,7 @@ def args():
         csv_file = 'results.csv'
         scale_factor = None
         explain_analyze = False
+        use_server_side_cursors = False
         check_correctness = False
         netdata_output_file = 'foobar.dat'
 


### PR DESCRIPTION
In version 5.3.0 we're introducing the possibility to run parallel queries through server-side (a.k.a. named) cursors. To test this feature regularly in a fairly realistic scenario, we extended the benchmark toolkit to have a mode in which all queries are executed through server-side cursors (currently client-side cursors are used). This must be a separate mode because running queries against native PSQL would otherwise turn completely sequential.

See https://github.com/psycopg/psycopg2/issues/941 for why turning the connection into transaction mode is so ugly.