### PR TITLE
Feature/numeric in schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ Parameter      | Description
 
 ### Schema Parameter Values
 
-Value                   | Description
------------------------ | -----------
-`psql_native`           | the standard PostgreSQL schema
-`s64da_native`          | as above but with the S64 DA extension with its default feature set enabled
-`s64da_native_enhanced` | as above, but with some of the S64 DA opt-in features enabled, such as `columnstore` index
-`s64da_performance`     | schema that provides the best performance for S64 DA
+Value                         | Description
+----------------------------- | -----------
+`psql_native`                 | the standard PostgreSQL schema
+`s64da_native`                | as above but with the S64 DA extension with its default feature set enabled
+`s64da_native_enhanced`       | as above but with some of the S64 DA opt-in features enabled, such as `columnstore` index
+`s64da_performance`           | schema that provides the best performance for S64 DA (includes removal of btree indexes, keys, and use of floating point)
+`*_partitioned_id_hashed`     | schema like one of first four schemas but partitioning some tables using hash on main id column of the table
+`*_partitioned_date_week`     | schema like one of first four schemas but partitioning tables with dates by weeks
 
 ## Optional Parameters
 

--- a/benchmarks/tpcds/schemas/s64da_native_enhanced_partitioned_id_hashed/schema.sql
+++ b/benchmarks/tpcds/schemas/s64da_native_enhanced_partitioned_id_hashed/schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE customer_address
     ca_state                  VARCHAR(2),
     ca_zip                    VARCHAR(10),
     ca_country                VARCHAR(20),
-    ca_gmt_offset             DOUBLE PRECISION,
+    ca_gmt_offset             DECIMAL(5,2),
     ca_location_type          VARCHAR(20)
 ) PARTITION BY HASH(ca_address_sk);
 SELECT * FROM partition_by_hash('customer_address', 50);
@@ -82,7 +82,7 @@ CREATE TABLE warehouse
     w_state                   VARCHAR(2),
     w_zip                     VARCHAR(10),
     w_country                 VARCHAR(20),
-    w_gmt_offset              DOUBLE PRECISION
+    w_gmt_offset              DECIMAL(5,2)
 );
 
 CREATE TABLE ship_mode
@@ -130,8 +130,8 @@ CREATE TABLE item
     i_rec_start_date          DATE,
     i_rec_end_date            DATE,
     i_item_desc               VARCHAR(200),
-    i_current_price           DOUBLE PRECISION,
-    i_wholesale_cost          DOUBLE PRECISION,
+    i_current_price           DECIMAL(7,2),
+    i_wholesale_cost          DECIMAL(7,2),
     i_brand_id                BIGINT,
     i_brand                   VARCHAR(50),
     i_class_id                BIGINT,
@@ -178,8 +178,8 @@ CREATE TABLE store
     s_state                   VARCHAR(2),
     s_zip                     VARCHAR(10),
     s_country                 VARCHAR(20),
-    s_gmt_offset              DOUBLE PRECISION,
-    s_tax_precentage          DOUBLE PRECISION
+    s_gmt_offset              DECIMAL(5,2),
+    s_tax_precentage          DECIMAL(5,2)
 );
 
 CREATE TABLE call_center
@@ -213,8 +213,8 @@ CREATE TABLE call_center
     cc_state                  VARCHAR(2),
     cc_zip                    VARCHAR(10),
     cc_country                VARCHAR(20),
-    cc_gmt_offset             DOUBLE PRECISION,
-    cc_tax_percentage         DOUBLE PRECISION
+    cc_gmt_offset             DECIMAL(5,2),
+    cc_tax_percentage         DECIMAL(5,2)
 );
 
 CREATE TABLE customer
@@ -266,8 +266,8 @@ CREATE TABLE web_site
     web_state                 VARCHAR(2),
     web_zip                   VARCHAR(10),
     web_country               VARCHAR(20),
-    web_gmt_offset            DOUBLE PRECISION,
-    web_tax_percentage        DOUBLE PRECISION
+    web_gmt_offset            DECIMAL(5,2),
+    web_tax_percentage        DECIMAL(5,2)
 );
 
 CREATE TABLE store_returns
@@ -283,15 +283,15 @@ CREATE TABLE store_returns
     sr_reason_sk              INTEGER,
     sr_ticket_number          INTEGER               NOT NULL,
     sr_return_quantity        BIGINT,
-    sr_return_amt             DOUBLE PRECISION,
-    sr_return_tax             DOUBLE PRECISION,
-    sr_return_amt_inc_tax     DOUBLE PRECISION,
-    sr_fee                    DOUBLE PRECISION,
-    sr_return_ship_cost       DOUBLE PRECISION,
-    sr_refunded_cash          DOUBLE PRECISION,
-    sr_reversed_charge        DOUBLE PRECISION,
-    sr_store_credit           DOUBLE PRECISION,
-    sr_net_loss               DOUBLE PRECISION
+    sr_return_amt             DECIMAL(7,2),
+    sr_return_tax             DECIMAL(7,2),
+    sr_return_amt_inc_tax     DECIMAL(7,2),
+    sr_fee                    DECIMAL(7,2),
+    sr_return_ship_cost       DECIMAL(7,2),
+    sr_refunded_cash          DECIMAL(7,2),
+    sr_reversed_charge        DECIMAL(7,2),
+    sr_store_credit           DECIMAL(7,2),
+    sr_net_loss               DECIMAL(7,2)
 ) PARTITION BY HASH(sr_item_sk);
 SELECT * FROM partition_by_hash('store_returns', 50);
 
@@ -387,15 +387,15 @@ CREATE TABLE catalog_returns
     cr_reason_sk              INTEGER,
     cr_order_number           INTEGER               NOT NULL,
     cr_return_quantity        BIGINT,
-    cr_return_amount          DOUBLE PRECISION,
-    cr_return_tax             DOUBLE PRECISION,
-    cr_return_amt_inc_tax     DOUBLE PRECISION,
-    cr_fee                    DOUBLE PRECISION,
-    cr_return_ship_cost       DOUBLE PRECISION,
-    cr_refunded_cash          DOUBLE PRECISION,
-    cr_reversed_charge        DOUBLE PRECISION,
-    cr_store_credit           DOUBLE PRECISION,
-    cr_net_loss               DOUBLE PRECISION
+    cr_return_amount          DECIMAL(7,2),
+    cr_return_tax             DECIMAL(7,2),
+    cr_return_amt_inc_tax     DECIMAL(7,2),
+    cr_fee                    DECIMAL(7,2),
+    cr_return_ship_cost       DECIMAL(7,2),
+    cr_refunded_cash          DECIMAL(7,2),
+    cr_reversed_charge        DECIMAL(7,2),
+    cr_store_credit           DECIMAL(7,2),
+    cr_net_loss               DECIMAL(7,2)
 ) PARTITION BY HASH(cr_item_sk);
 SELECT * FROM partition_by_hash('catalog_returns', 50);
 
@@ -416,15 +416,15 @@ CREATE TABLE web_returns
     wr_reason_sk              INTEGER,
     wr_order_number           INTEGER               NOT NULL,
     wr_return_quantity        BIGINT,
-    wr_return_amt             DOUBLE PRECISION,
-    wr_return_tax             DOUBLE PRECISION,
-    wr_return_amt_inc_tax     DOUBLE PRECISION,
-    wr_fee                    DOUBLE PRECISION,
-    wr_return_ship_cost       DOUBLE PRECISION,
-    wr_refunded_cash          DOUBLE PRECISION,
-    wr_reversed_charge        DOUBLE PRECISION,
-    wr_account_credit         DOUBLE PRECISION,
-    wr_net_loss               DOUBLE PRECISION
+    wr_return_amt             DECIMAL(7,2),
+    wr_return_tax             DECIMAL(7,2),
+    wr_return_amt_inc_tax     DECIMAL(7,2),
+    wr_fee                    DECIMAL(7,2),
+    wr_return_ship_cost       DECIMAL(7,2),
+    wr_refunded_cash          DECIMAL(7,2),
+    wr_reversed_charge        DECIMAL(7,2),
+    wr_account_credit         DECIMAL(7,2),
+    wr_net_loss               DECIMAL(7,2)
 ) PARTITION BY HASH(wr_item_sk);
 SELECT * FROM partition_by_hash('web_returns', 50);
 
@@ -449,21 +449,21 @@ CREATE TABLE web_sales
     ws_promo_sk               INTEGER,
     ws_order_number           INTEGER               NOT NULL,
     ws_quantity               BIGINT,
-    ws_wholesale_cost         DOUBLE PRECISION,
-    ws_list_price             DOUBLE PRECISION,
-    ws_sales_price            DOUBLE PRECISION,
-    ws_ext_discount_amt       DOUBLE PRECISION,
-    ws_ext_sales_price        DOUBLE PRECISION,
-    ws_ext_wholesale_cost     DOUBLE PRECISION,
-    ws_ext_list_price         DOUBLE PRECISION,
-    ws_ext_tax                DOUBLE PRECISION,
-    ws_coupon_amt             DOUBLE PRECISION,
-    ws_ext_ship_cost          DOUBLE PRECISION,
-    ws_net_paid               DOUBLE PRECISION,
-    ws_net_paid_inc_tax       DOUBLE PRECISION,
-    ws_net_paid_inc_ship      DOUBLE PRECISION,
-    ws_net_paid_inc_ship_tax  DOUBLE PRECISION,
-    ws_net_profit             DOUBLE PRECISION
+    ws_wholesale_cost         DECIMAL(7,2),
+    ws_list_price             DECIMAL(7,2),
+    ws_sales_price            DECIMAL(7,2),
+    ws_ext_discount_amt       DECIMAL(7,2),
+    ws_ext_sales_price        DECIMAL(7,2),
+    ws_ext_wholesale_cost     DECIMAL(7,2),
+    ws_ext_list_price         DECIMAL(7,2),
+    ws_ext_tax                DECIMAL(7,2),
+    ws_coupon_amt             DECIMAL(7,2),
+    ws_ext_ship_cost          DECIMAL(7,2),
+    ws_net_paid               DECIMAL(7,2),
+    ws_net_paid_inc_tax       DECIMAL(7,2),
+    ws_net_paid_inc_ship      DECIMAL(7,2),
+    ws_net_paid_inc_ship_tax  DECIMAL(7,2),
+    ws_net_profit             DECIMAL(7,2)
 ) PARTITION BY HASH(ws_item_sk);
 SELECT * FROM partition_by_hash('web_sales', 50);
 
@@ -488,21 +488,21 @@ CREATE TABLE catalog_sales
     cs_promo_sk               INTEGER,
     cs_order_number           INTEGER               NOT NULL,
     cs_quantity               BIGINT,
-    cs_wholesale_cost         DOUBLE PRECISION,
-    cs_list_price             DOUBLE PRECISION,
-    cs_sales_price            DOUBLE PRECISION,
-    cs_ext_discount_amt       DOUBLE PRECISION,
-    cs_ext_sales_price        DOUBLE PRECISION,
-    cs_ext_wholesale_cost     DOUBLE PRECISION,
-    cs_ext_list_price         DOUBLE PRECISION,
-    cs_ext_tax                DOUBLE PRECISION,
-    cs_coupon_amt             DOUBLE PRECISION,
-    cs_ext_ship_cost          DOUBLE PRECISION,
-    cs_net_paid               DOUBLE PRECISION,
-    cs_net_paid_inc_tax       DOUBLE PRECISION,
-    cs_net_paid_inc_ship      DOUBLE PRECISION,
-    cs_net_paid_inc_ship_tax  DOUBLE PRECISION,
-    cs_net_profit             DOUBLE PRECISION
+    cs_wholesale_cost         DECIMAL(7,2),
+    cs_list_price             DECIMAL(7,2),
+    cs_sales_price            DECIMAL(7,2),
+    cs_ext_discount_amt       DECIMAL(7,2),
+    cs_ext_sales_price        DECIMAL(7,2),
+    cs_ext_wholesale_cost     DECIMAL(7,2),
+    cs_ext_list_price         DECIMAL(7,2),
+    cs_ext_tax                DECIMAL(7,2),
+    cs_coupon_amt             DECIMAL(7,2),
+    cs_ext_ship_cost          DECIMAL(7,2),
+    cs_net_paid               DECIMAL(7,2),
+    cs_net_paid_inc_tax       DECIMAL(7,2),
+    cs_net_paid_inc_ship      DECIMAL(7,2),
+    cs_net_paid_inc_ship_tax  DECIMAL(7,2),
+    cs_net_profit             DECIMAL(7,2)
 ) PARTITION BY HASH(cs_item_sk);
 SELECT * FROM partition_by_hash('catalog_sales', 50);
 
@@ -519,17 +519,17 @@ CREATE TABLE store_sales
     ss_promo_sk               INTEGER,
     ss_ticket_number          INTEGER               NOT NULL,
     ss_quantity               BIGINT,
-    ss_wholesale_cost         DOUBLE PRECISION,
-    ss_list_price             DOUBLE PRECISION,
-    ss_sales_price            DOUBLE PRECISION,
-    ss_ext_discount_amt       DOUBLE PRECISION,
-    ss_ext_sales_price        DOUBLE PRECISION,
-    ss_ext_wholesale_cost     DOUBLE PRECISION,
-    ss_ext_list_price         DOUBLE PRECISION,
-    ss_ext_tax                DOUBLE PRECISION,
-    ss_coupon_amt             DOUBLE PRECISION,
-    ss_net_paid               DOUBLE PRECISION,
-    ss_net_paid_inc_tax       DOUBLE PRECISION,
-    ss_net_profit             DOUBLE PRECISION
+    ss_wholesale_cost         DECIMAL(7,2),
+    ss_list_price             DECIMAL(7,2),
+    ss_sales_price            DECIMAL(7,2),
+    ss_ext_discount_amt       DECIMAL(7,2),
+    ss_ext_sales_price        DECIMAL(7,2),
+    ss_ext_wholesale_cost     DECIMAL(7,2),
+    ss_ext_list_price         DECIMAL(7,2),
+    ss_ext_tax                DECIMAL(7,2),
+    ss_coupon_amt             DECIMAL(7,2),
+    ss_net_paid               DECIMAL(7,2),
+    ss_net_paid_inc_tax       DECIMAL(7,2),
+    ss_net_profit             DECIMAL(7,2)
 ) PARTITION BY HASH(ss_item_sk);
 SELECT * FROM partition_by_hash('store_sales', 50);

--- a/benchmarks/tpch/schemas/psql_native/schema.sql
+++ b/benchmarks/tpch/schemas/psql_native/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE part (
     p_type character varying(25) NOT NULL,
     p_size int NOT NULL,
     p_container character varying(10) NOT NULL,
-    p_retailprice double precision NOT NULL,
+    p_retailprice numeric(13,2) NOT NULL,
     p_comment character varying(23) NOT NULL
 );
 
@@ -29,7 +29,7 @@ CREATE TABLE supplier (
     s_address character varying(40) NOT NULL,
     s_nationkey int NOT NULL,
     s_phone character varying(15) NOT NULL,
-    s_acctbal double precision NOT NULL,
+    s_acctbal numeric(13,2) NOT NULL,
     s_comment character varying(101) NOT NULL
 );
 
@@ -37,7 +37,7 @@ CREATE TABLE partsupp (
     ps_partkey int NOT NULL,
     ps_suppkey int NOT NULL,
     ps_availqty int NOT NULL,
-    ps_supplycost double precision NOT NULL,
+    ps_supplycost numeric(13,2) NOT NULL,
     ps_comment character varying(199) NOT NULL
 );
 
@@ -47,7 +47,7 @@ CREATE TABLE customer (
     c_address character varying(40) NOT NULL,
     c_nationkey int NOT NULL,
     c_phone character varying(15) NOT NULL,
-    c_acctbal double precision NOT NULL,
+    c_acctbal numeric(13,2) NOT NULL,
     c_mktsegment character varying(10) NOT NULL,
     c_comment character varying(117) NOT NULL
 );
@@ -56,7 +56,7 @@ CREATE TABLE orders (
     o_orderkey bigint NOT NULL,
     o_custkey int NOT NULL,
     o_orderstatus "char" NOT NULL,
-    o_totalprice double precision NOT NULL,
+    o_totalprice numeric(13,2) NOT NULL,
     o_orderdate date NOT NULL,
     o_orderpriority character varying(15) NOT NULL,
     o_clerk character varying(15) NOT NULL,
@@ -69,10 +69,10 @@ CREATE TABLE lineitem (
     l_partkey int NOT NULL,
     l_suppkey int NOT NULL,
     l_linenumber int NOT NULL,
-    l_quantity double precision NOT NULL,
-    l_extendedprice double precision NOT NULL,
-    l_discount double precision NOT NULL,
-    l_tax double precision NOT NULL,
+    l_quantity numeric(13,2) NOT NULL,
+    l_extendedprice numeric(13,2) NOT NULL,
+    l_discount numeric(13,2) NOT NULL,
+    l_tax numeric(13,2) NOT NULL,
     l_returnflag "char" NOT NULL,
     l_linestatus "char" NOT NULL,
     l_shipdate date NOT NULL,

--- a/benchmarks/tpch/schemas/psql_native_partitioned_date_week/schema.sql
+++ b/benchmarks/tpch/schemas/psql_native_partitioned_date_week/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE part (
     p_type character varying(25) NOT NULL,
     p_size int NOT NULL,
     p_container character varying(10) NOT NULL,
-    p_retailprice double precision NOT NULL,
+    p_retailprice numeric(13,2) NOT NULL,
     p_comment character varying(23) NOT NULL
 );
 
@@ -29,7 +29,7 @@ CREATE TABLE supplier (
     s_address character varying(40) NOT NULL,
     s_nationkey int NOT NULL,
     s_phone character varying(15) NOT NULL,
-    s_acctbal double precision NOT NULL,
+    s_acctbal numeric(13,2) NOT NULL,
     s_comment character varying(101) NOT NULL
 );
 
@@ -37,7 +37,7 @@ CREATE TABLE partsupp (
     ps_partkey int NOT NULL,
     ps_suppkey int NOT NULL,
     ps_availqty int NOT NULL,
-    ps_supplycost double precision NOT NULL,
+    ps_supplycost numeric(13,2) NOT NULL,
     ps_comment character varying(199) NOT NULL
 );
 
@@ -47,7 +47,7 @@ CREATE TABLE customer (
     c_address character varying(40) NOT NULL,
     c_nationkey int NOT NULL,
     c_phone character varying(15) NOT NULL,
-    c_acctbal double precision NOT NULL,
+    c_acctbal numeric(13,2) NOT NULL,
     c_mktsegment character varying(10) NOT NULL,
     c_comment character varying(117) NOT NULL
 );
@@ -56,7 +56,7 @@ CREATE TABLE orders (
     o_orderkey bigint NOT NULL,
     o_custkey int NOT NULL,
     o_orderstatus "char" NOT NULL,
-    o_totalprice double precision NOT NULL,
+    o_totalprice numeric(13,2) NOT NULL,
     o_orderdate date NOT NULL,
     o_orderpriority character varying(15) NOT NULL,
     o_clerk character varying(15) NOT NULL,
@@ -503,10 +503,10 @@ CREATE TABLE lineitem (
     l_partkey int NOT NULL,
     l_suppkey int NOT NULL,
     l_linenumber int NOT NULL,
-    l_quantity double precision NOT NULL,
-    l_extendedprice double precision NOT NULL,
-    l_discount double precision NOT NULL,
-    l_tax double precision NOT NULL,
+    l_quantity numeric(13,2) NOT NULL,
+    l_extendedprice numeric(13,2) NOT NULL,
+    l_discount numeric(13,2) NOT NULL,
+    l_tax numeric(13,2) NOT NULL,
     l_returnflag "char" NOT NULL,
     l_linestatus "char" NOT NULL,
     l_shipdate date NOT NULL,

--- a/benchmarks/tpch/schemas/psql_native_partitioned_id_hashed/schema.sql
+++ b/benchmarks/tpch/schemas/psql_native_partitioned_id_hashed/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE part (
     p_type character varying(25) NOT NULL,
     p_size int NOT NULL,
     p_container character varying(10) NOT NULL,
-    p_retailprice double precision NOT NULL,
+    p_retailprice numeric(13,2) NOT NULL,
     p_comment character varying(23) NOT NULL
 ) PARTITION BY HASH(p_partkey);
 SELECT * FROM partition_by_hash('part', 32);
@@ -30,7 +30,7 @@ CREATE TABLE supplier (
     s_address character varying(40) NOT NULL,
     s_nationkey int NOT NULL,
     s_phone character varying(15) NOT NULL,
-    s_acctbal double precision NOT NULL,
+    s_acctbal numeric(13,2) NOT NULL,
     s_comment character varying(101) NOT NULL
 ) PARTITION BY HASH(s_suppkey);
 SELECT * FROM partition_by_hash('supplier', 32);
@@ -39,7 +39,7 @@ CREATE TABLE partsupp (
     ps_partkey int NOT NULL,
     ps_suppkey int NOT NULL,
     ps_availqty int NOT NULL,
-    ps_supplycost double precision NOT NULL,
+    ps_supplycost numeric(13,2) NOT NULL,
     ps_comment character varying(199) NOT NULL
 ) PARTITION BY HASH(ps_partkey);
 SELECT * FROM partition_by_hash('partsupp', 32);
@@ -50,7 +50,7 @@ CREATE TABLE customer (
     c_address character varying(40) NOT NULL,
     c_nationkey int NOT NULL,
     c_phone character varying(15) NOT NULL,
-    c_acctbal double precision NOT NULL,
+    c_acctbal numeric(13,2) NOT NULL,
     c_mktsegment character varying(10) NOT NULL,
     c_comment character varying(117) NOT NULL
 ) PARTITION BY HASH(c_custkey);
@@ -60,7 +60,7 @@ CREATE TABLE orders (
     o_orderkey bigint NOT NULL,
     o_custkey int NOT NULL,
     o_orderstatus "char" NOT NULL,
-    o_totalprice double precision NOT NULL,
+    o_totalprice numeric(13,2) NOT NULL,
     o_orderdate date NOT NULL,
     o_orderpriority character varying(15) NOT NULL,
     o_clerk character varying(15) NOT NULL,
@@ -74,10 +74,10 @@ CREATE TABLE lineitem (
     l_partkey int NOT NULL,
     l_suppkey int NOT NULL,
     l_linenumber int NOT NULL,
-    l_quantity double precision NOT NULL,
-    l_extendedprice double precision NOT NULL,
-    l_discount double precision NOT NULL,
-    l_tax double precision NOT NULL,
+    l_quantity numeric(13,2) NOT NULL,
+    l_extendedprice numeric(13,2) NOT NULL,
+    l_discount numeric(13,2) NOT NULL,
+    l_tax numeric(13,2) NOT NULL,
     l_returnflag "char" NOT NULL,
     l_linestatus "char" NOT NULL,
     l_shipdate date NOT NULL,

--- a/benchmarks/tpch/schemas/s64da_native/schema.sql
+++ b/benchmarks/tpch/schemas/s64da_native/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE part (
     p_type character varying(25) NOT NULL,
     p_size int NOT NULL,
     p_container character varying(10) NOT NULL,
-    p_retailprice double precision NOT NULL,
+    p_retailprice numeric(13,2) NOT NULL,
     p_comment character varying(23) NOT NULL
 );
 
@@ -29,7 +29,7 @@ CREATE TABLE supplier (
     s_address character varying(40) NOT NULL,
     s_nationkey int NOT NULL,
     s_phone character varying(15) NOT NULL,
-    s_acctbal double precision NOT NULL,
+    s_acctbal numeric(13,2) NOT NULL,
     s_comment character varying(101) NOT NULL
 );
 
@@ -37,7 +37,7 @@ CREATE TABLE partsupp (
     ps_partkey int NOT NULL,
     ps_suppkey int NOT NULL,
     ps_availqty int NOT NULL,
-    ps_supplycost double precision NOT NULL,
+    ps_supplycost numeric(13,2) NOT NULL,
     ps_comment character varying(199) NOT NULL
 );
 
@@ -47,7 +47,7 @@ CREATE TABLE customer (
     c_address character varying(40) NOT NULL,
     c_nationkey int NOT NULL,
     c_phone character varying(15) NOT NULL,
-    c_acctbal double precision NOT NULL,
+    c_acctbal numeric(13,2) NOT NULL,
     c_mktsegment character varying(10) NOT NULL,
     c_comment character varying(117) NOT NULL
 );
@@ -56,7 +56,7 @@ CREATE TABLE orders (
     o_orderkey bigint NOT NULL,
     o_custkey int NOT NULL,
     o_orderstatus "char" NOT NULL,
-    o_totalprice double precision NOT NULL,
+    o_totalprice numeric(13,2) NOT NULL,
     o_orderdate date NOT NULL,
     o_orderpriority character varying(15) NOT NULL,
     o_clerk character varying(15) NOT NULL,
@@ -69,10 +69,10 @@ CREATE TABLE lineitem (
     l_partkey int NOT NULL,
     l_suppkey int NOT NULL,
     l_linenumber int NOT NULL,
-    l_quantity double precision NOT NULL,
-    l_extendedprice double precision NOT NULL,
-    l_discount double precision NOT NULL,
-    l_tax double precision NOT NULL,
+    l_quantity numeric(13,2) NOT NULL,
+    l_extendedprice numeric(13,2) NOT NULL,
+    l_discount numeric(13,2) NOT NULL,
+    l_tax numeric(13,2) NOT NULL,
     l_returnflag "char" NOT NULL,
     l_linestatus "char" NOT NULL,
     l_shipdate date NOT NULL,

--- a/benchmarks/tpch/schemas/s64da_native_enhanced/schema.sql
+++ b/benchmarks/tpch/schemas/s64da_native_enhanced/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE part (
     p_type character varying(25) NOT NULL,
     p_size int NOT NULL,
     p_container character varying(10) NOT NULL,
-    p_retailprice double precision NOT NULL,
+    p_retailprice numeric(13,2) NOT NULL,
     p_comment character varying(23) NOT NULL
 );
 
@@ -29,7 +29,7 @@ CREATE TABLE supplier (
     s_address character varying(40) NOT NULL,
     s_nationkey int NOT NULL,
     s_phone character varying(15) NOT NULL,
-    s_acctbal double precision NOT NULL,
+    s_acctbal numeric(13,2) NOT NULL,
     s_comment character varying(101) NOT NULL
 );
 
@@ -37,7 +37,7 @@ CREATE TABLE partsupp (
     ps_partkey int NOT NULL,
     ps_suppkey int NOT NULL,
     ps_availqty int NOT NULL,
-    ps_supplycost double precision NOT NULL,
+    ps_supplycost numeric(13,2) NOT NULL,
     ps_comment character varying(199) NOT NULL
 );
 
@@ -47,7 +47,7 @@ CREATE TABLE customer (
     c_address character varying(40) NOT NULL,
     c_nationkey int NOT NULL,
     c_phone character varying(15) NOT NULL,
-    c_acctbal double precision NOT NULL,
+    c_acctbal numeric(13,2) NOT NULL,
     c_mktsegment character varying(10) NOT NULL,
     c_comment character varying(117) NOT NULL
 );
@@ -56,7 +56,7 @@ CREATE TABLE orders (
     o_orderkey bigint NOT NULL,
     o_custkey int NOT NULL,
     o_orderstatus "char" NOT NULL,
-    o_totalprice double precision NOT NULL,
+    o_totalprice numeric(13,2) NOT NULL,
     o_orderdate date NOT NULL,
     o_orderpriority character varying(15) NOT NULL,
     o_clerk character varying(15) NOT NULL,
@@ -69,10 +69,10 @@ CREATE TABLE lineitem (
     l_partkey int NOT NULL,
     l_suppkey int NOT NULL,
     l_linenumber int NOT NULL,
-    l_quantity double precision NOT NULL,
-    l_extendedprice double precision NOT NULL,
-    l_discount double precision NOT NULL,
-    l_tax double precision NOT NULL,
+    l_quantity numeric(13,2) NOT NULL,
+    l_extendedprice numeric(13,2) NOT NULL,
+    l_discount numeric(13,2) NOT NULL,
+    l_tax numeric(13,2) NOT NULL,
     l_returnflag "char" NOT NULL,
     l_linestatus "char" NOT NULL,
     l_shipdate date NOT NULL,

--- a/benchmarks/tpch/schemas/s64da_native_enhanced_partitioned_id_hashed/schema.sql
+++ b/benchmarks/tpch/schemas/s64da_native_enhanced_partitioned_id_hashed/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE part (
     p_type character varying(25) NOT NULL,
     p_size int NOT NULL,
     p_container character varying(10) NOT NULL,
-    p_retailprice double precision NOT NULL,
+    p_retailprice numeric(13,2) NOT NULL,
     p_comment character varying(23) NOT NULL
 ) PARTITION BY HASH(p_partkey);
 SELECT * FROM partition_by_hash('part', 32);
@@ -30,7 +30,7 @@ CREATE TABLE supplier (
     s_address character varying(40) NOT NULL,
     s_nationkey int NOT NULL,
     s_phone character varying(15) NOT NULL,
-    s_acctbal double precision NOT NULL,
+    s_acctbal numeric(13,2) NOT NULL,
     s_comment character varying(101) NOT NULL
 ) PARTITION BY HASH(s_suppkey);
 SELECT * FROM partition_by_hash('supplier', 32);
@@ -39,7 +39,7 @@ CREATE TABLE partsupp (
     ps_partkey int NOT NULL,
     ps_suppkey int NOT NULL,
     ps_availqty int NOT NULL,
-    ps_supplycost double precision NOT NULL,
+    ps_supplycost numeric(13,2) NOT NULL,
     ps_comment character varying(199) NOT NULL
 ) PARTITION BY HASH(ps_partkey);
 SELECT * FROM partition_by_hash('partsupp', 32);
@@ -50,7 +50,7 @@ CREATE TABLE customer (
     c_address character varying(40) NOT NULL,
     c_nationkey int NOT NULL,
     c_phone character varying(15) NOT NULL,
-    c_acctbal double precision NOT NULL,
+    c_acctbal numeric(13,2) NOT NULL,
     c_mktsegment character varying(10) NOT NULL,
     c_comment character varying(117) NOT NULL
 ) PARTITION BY HASH(c_custkey);
@@ -60,7 +60,7 @@ CREATE TABLE orders (
     o_orderkey bigint NOT NULL,
     o_custkey int NOT NULL,
     o_orderstatus "char" NOT NULL,
-    o_totalprice double precision NOT NULL,
+    o_totalprice numeric(13,2) NOT NULL,
     o_orderdate date NOT NULL,
     o_orderpriority character varying(15) NOT NULL,
     o_clerk character varying(15) NOT NULL,
@@ -74,10 +74,10 @@ CREATE TABLE lineitem (
     l_partkey int NOT NULL,
     l_suppkey int NOT NULL,
     l_linenumber int NOT NULL,
-    l_quantity double precision NOT NULL,
-    l_extendedprice double precision NOT NULL,
-    l_discount double precision NOT NULL,
-    l_tax double precision NOT NULL,
+    l_quantity numeric(13,2) NOT NULL,
+    l_extendedprice numeric(13,2) NOT NULL,
+    l_discount numeric(13,2) NOT NULL,
+    l_tax numeric(13,2) NOT NULL,
     l_returnflag "char" NOT NULL,
     l_linestatus "char" NOT NULL,
     l_shipdate date NOT NULL,


### PR DESCRIPTION
Use numeric in all  "*_native_*" schemas, but use floating point in all "*_performance_*" schemas for both TPCH and TPCDS