### PR TITLE
allow fast ingest and limit memory usage

### DIFF
--- a/benchmarks/htap/htap_loader.py
+++ b/benchmarks/htap/htap_loader.py
@@ -6,7 +6,7 @@ from psycopg2.extras import execute_values
 from s64da_benchmark_toolkit.dbconn import DBConn
 
 from benchmarks.htap.lib.helpers import (
-        Random, TPCCText, TPCHText, NATIONS, REGIONS, TimestampGenerator
+        Random, TPCCText, TPCHText, NATIONS, REGIONS, TimestampGenerator, StringIteratorIO
 )
 
 MAXITEMS = 100000
@@ -18,6 +18,7 @@ NUM_SUPPLIERS = 10000
 NUM_NATIONS = 62
 NUM_REGIONS = 5
 
+COPY_SIZE=16384
 
 class TPCCLoader():
     def __init__(self, dsn, warehouse_id, scale_factor, start_date=None):
@@ -33,6 +34,25 @@ class TPCCLoader():
         with DBConn(self.dsn) as conn:
             sql = f'INSERT INTO {table} VALUES %s'
             execute_values(conn.cursor, sql, data)
+
+    def row_for_copy(self, row):
+        return '\t'.join([str(v) for v in row]) + '\n'
+
+    def load_region(self):
+        print('Loading regions')
+        assert self.warehouse_id == 0
+        with DBConn(self.dsn) as conn:
+            for i in range(NUM_REGIONS):
+                region_key, name = REGIONS[i]
+                self.insert_data('region', [[region_key, name, self.tpch_text.random_length_text(31, 115)]])
+
+    def load_nation(self):
+        print('Loading nation')
+        assert self.warehouse_id == 0
+        with DBConn(self.dsn) as conn:
+            for i in range(NUM_NATIONS):
+                nation_key, name, region_key = NATIONS[i]
+                self.insert_data('nation', [[nation_key, name, region_key, self.tpch_text.random_length_text(31, 114)]])
 
     def load_warehouse(self):
         print(f'Loading warehouse ({self.warehouse_id})')
@@ -52,237 +72,210 @@ class TPCCLoader():
                 ]
         )
 
+    def generate_district(self, d_id):
+        return self.row_for_copy([
+            d_id,
+            self.warehouse_id,
+            self.tpcc_text.string(5, prefix='name-'),
+            self.tpcc_text.string(10, prefix='street1-'),
+            self.tpcc_text.string(10, prefix='street2-'),
+            self.tpcc_text.string(10, prefix='city-'),
+            self.tpcc_text.state(),
+            self.tpcc_text.numstring(5, prefix='zip-'),
+            self.random.sample() * 0.2,
+            30000,
+            3001,
+        ])
+
     def load_district(self):
         print(f'Loading district ({self.warehouse_id})')
         with DBConn(self.dsn) as conn:
-            f = StringIO()
-            for d_id in range(1, DIST_PER_WARE + 1):
-                row = [
-                        d_id,
-                        self.warehouse_id,
-                        self.tpcc_text.string(5, prefix='name-'),
-                        self.tpcc_text.string(10, prefix='street1-'),
-                        self.tpcc_text.string(10, prefix='street2-'),
-                        self.tpcc_text.string(10, prefix='city-'),
-                        self.tpcc_text.state(),
-                        self.tpcc_text.numstring(5, prefix='zip-'),
-                        self.random.sample() * 0.2,
-                        30000,
-                        3001,
-                ]
-                f.write('\t'.join([str(v) for v in row]) + '\n')
+            it = StringIteratorIO((
+                self.generate_district(d_id)
+                for d_id in range(1, DIST_PER_WARE + 1)
+            ))
+            conn.cursor.copy_from(it, 'district', null='None', size=COPY_SIZE)
 
-            f.seek(SEEK_SET)
-            conn.cursor.copy_from(f, 'district', null='None')
+
+    def generate_customer(self, d_id, c_id):
+        c_last = self.tpcc_text.lastname(c_id - 1) if c_id < 1000 else \
+            self.tpcc_text.lastname(self.random.nurand(255, 0, 999))
+
+        return self.row_for_copy([
+            c_id, d_id, self.warehouse_id,
+            self.tpcc_text.string(self.random.randint_inclusive(2, 10), prefix='first-'),
+            'OE', c_last,
+            self.tpcc_text.string(10, prefix='street1-'),
+            self.tpcc_text.string(10, prefix='street2-'),
+            self.tpcc_text.string(10, prefix='city-'),
+            self.tpcc_text.state(),
+            self.tpcc_text.numstring(5, prefix='zip-'),
+            self.tpcc_text.numstring(16), self.start_date,
+            'GC' if self.random.randint_inclusive(1, 100) > 10 else 'BC', 50000,
+            self.random.sample() * 0.5, -10, 10, 1, 0,
+            self.tpcc_text.string(self.random.randint_inclusive(300, 500))
+        ])
 
     def load_customer(self):
         print(f'Loading customer ({self.warehouse_id})')
         with DBConn(self.dsn) as conn:
-            for d_id in range(1, DIST_PER_WARE + 1):
-                f = StringIO()
-                for c_id in range(1, CUST_PER_DIST + 1):
-                    c_last = self.tpcc_text.lastname(c_id - 1) if c_id < 1000 else \
-                            self.tpcc_text.lastname(self.random.nurand(255, 0, 999))
+            it = StringIteratorIO((
+                self.generate_customer(d_id, c_id)
+                for d_id in range(1, DIST_PER_WARE + 1)
+                for c_id in range(1, CUST_PER_DIST + 1)
+            ))
+            conn.cursor.copy_from(it, 'customer', null='None', size=COPY_SIZE)
 
-                    row = [
-                            c_id, d_id, self.warehouse_id,
-                            self.tpcc_text.string(
-                                    self.random.randint_inclusive(2, 10), prefix='first-'
-                            ), 'OE', c_last,
-                            self.tpcc_text.string(10, prefix='street1-'),
-                            self.tpcc_text.string(10, prefix='street2-'),
-                            self.tpcc_text.string(10, prefix='city-'),
-                            self.tpcc_text.state(),
-                            self.tpcc_text.numstring(5, prefix='zip-'),
-                            self.tpcc_text.numstring(16), self.start_date or 'NOW()',
-                            'GC' if self.random.randint_inclusive(1, 100) > 10 else 'BC', 50000,
-                            self.random.sample() * 0.5, -10, 10, 1, 0,
-                            self.tpcc_text.string(self.random.randint_inclusive(300, 500))
-                    ]
-                    f.write('\t'.join([str(v) for v in row]) + '\n')
-
-                f.seek(SEEK_SET)
-                conn.cursor.copy_from(f, 'customer', null='None')
+    def generate_history(self, d_id, c_id):
+        return self.row_for_copy([
+            c_id, d_id, self.warehouse_id, d_id, self.warehouse_id, self.start_date, 10,
+            self.tpcc_text.string(self.random.randint_inclusive(12, 24))
+        ])
 
     def load_history(self):
         print(f'Loading history ({self.warehouse_id})')
-        with DBConn(self.dsn) as conn:
-            f = StringIO()
-            for d_id in range(1, DIST_PER_WARE + 1):
-                for c_id in range(1, CUST_PER_DIST):
-                    row = [
-                            c_id, d_id, self.warehouse_id, d_id, self.warehouse_id, self.start_date
-                            or 'NOW()', 10,
-                            self.tpcc_text.string(self.random.randint_inclusive(12, 24))
-                    ]
-                    f.write('\t'.join([str(v) for v in row]) + '\n')
+        copy_columns=('h_c_id', 'h_c_d_id', 'h_c_w_id', 'h_d_id', 'h_w_id', 'h_date', 'h_amount', 'h_data')
 
-            f.seek(SEEK_SET)
-            conn.cursor.copy_from(
-                    f,
-                    'history',
-                    null='None',
-                    columns=(
-                            'h_c_id', 'h_c_d_id', 'h_c_w_id', 'h_d_id', 'h_w_id', 'h_date',
-                            'h_amount', 'h_data'
-                    )
-            )
+        with DBConn(self.dsn) as conn:
+            it = StringIteratorIO((
+                self.generate_history(d_id, c_id)
+                for d_id in range(1, DIST_PER_WARE + 1)
+                for c_id in range(1, CUST_PER_DIST)
+            ))
+            conn.cursor.copy_from(it, 'history', null='None', columns=copy_columns, size=COPY_SIZE)
+
+    def generate_stock(self, s_id):
+        return self.row_for_copy([
+            s_id, self.warehouse_id,
+            self.random.randint_inclusive(10, 100),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24),
+            self.tpcc_text.string(24), 0, 0, 0,
+            self.tpcc_text.string(self.random.randint_inclusive(26, 50))
+        ])
 
     def load_stock(self):
         print(f'Loading stock ({self.warehouse_id})')
         with DBConn(self.dsn) as conn:
-            f = StringIO()
-            for s_id in range(1, STOCKS + 1):
-                row = [
-                        s_id, self.warehouse_id,
-                        self.random.randint_inclusive(10, 100),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24),
-                        self.tpcc_text.string(24), 0, 0, 0,
-                        self.tpcc_text.string(self.random.randint_inclusive(26, 50))
-                ]
-                f.write('\t'.join([str(v) for v in row]) + '\n')
+            it = StringIteratorIO((
+                self.generate_stock(s_id)
+                for s_id in range(1, STOCKS + 1)
+            ))
+            conn.cursor.copy_from(it, 'stock', null='None', size=COPY_SIZE)
 
-            f.seek(SEEK_SET)
-            conn.cursor.copy_from(f, 'stock', null='None')
+    def generate_order(self, d_id, o_id):
+        entry_date = self.timestamp_generator.next()
+        o_ol_cnt = self.random.randint_inclusive(5, 15)
+        self.order_lines.append((o_ol_cnt, entry_date))
 
-    def _load_orders_impl(self):
+        return self.row_for_copy([
+            o_id, d_id, self.warehouse_id, self.c_ids[o_id - 1], entry_date,
+            self.random.randint_inclusive(1, 10) if o_id < 2101 else None,
+            o_ol_cnt, 1
+        ])
+    
+    def generate_order_lines(self, d_id, o_id):
+        order_line_count, entry_date = self.order_lines[(d_id - 1) * NUM_ORDERS + o_id - 1]
+        rows = ""
+        for ol_id in range(1, order_line_count + 1):
+            rows += self.row_for_copy([
+                o_id, d_id, self.warehouse_id, ol_id,
+                self.random.randint_inclusive(1, MAXITEMS), self.warehouse_id,
+                entry_date if o_id < 2101 else None, 5,
+                0 if o_id < 2101 else self.random.sample() * 9999.99,
+                self.tpcc_text.string(24)
+            ])
+        return rows
+
+    def load_orders(self):
         print(f'Loading orders ({self.warehouse_id})')
-        c_ids = list(range(1, NUM_ORDERS + 1))
-        self.random.shuffle(c_ids)
-        order_line_infos = []
-        with DBConn(self.dsn) as conn:
-            f = StringIO()
-            for d_id in range(1, DIST_PER_WARE + 1):
-                for o_id in range(1, NUM_ORDERS + 1):
-                    entry_date = self.timestamp_generator.next()
-                    order_line_infos.append((self.random.randint_inclusive(5, 15), entry_date))
-                    row = [
-                            o_id, d_id, self.warehouse_id, c_ids[o_id - 1], entry_date,
-                            self.random.randint_inclusive(1, 10) if o_id < 2101 else None,
-                            order_line_infos[-1][0], 1
-                    ]
-                    line = '\t'.join([str(v) for v in row]) + '\n'
-                    f.write(line)
+        self.order_lines = []
+        self.c_ids = list(range(1, NUM_ORDERS + 1))
+        self.random.shuffle(self.c_ids)
 
-            f.seek(SEEK_SET)
-            conn.cursor.copy_from(f, 'orders', null='None')
+        with DBConn(self.dsn) as conn:
+            it = StringIteratorIO((
+                self.generate_order(d_id, o_id)
+                for d_id in range(1, DIST_PER_WARE + 1)
+                for o_id in range(1, NUM_ORDERS + 1)
+            ))
+            conn.cursor.copy_from(it, 'orders', null='None', size=COPY_SIZE)
 
         with DBConn(self.dsn) as conn:
             conn.cursor.execute(
-                    f'''
+                f'''
                 INSERT INTO new_orders(no_o_id, no_d_id, no_w_id)
                 SELECT o_id, o_d_id, o_w_id
                 FROM orders
                 WHERE o_id > 2100 AND o_w_id = { self.warehouse_id }'''
             )
 
-        return order_line_infos
 
-    def load_item(self):
-        print(f'Loading item ({self.warehouse_id})')
-        with DBConn(self.dsn) as conn:
-            f = StringIO()
-            for i_id in range(1, MAXITEMS + 1):
-                i_im_id = self.random.randint_inclusive(1, 10000)
-                i_price = self.random.sample() * 100 + 1
-
-                i_name_suffix = self.tpcc_text.string(5)
-                i_name = f'item-{i_im_id}-{i_price}-{i_name_suffix}'
-
-                if self.random.decision(1 / 10):
-                    i_data = self.tpcc_text.data_original(26, 50)
-                else:
-                    i_data = self.tpcc_text.data(26, 50)
-
-                row = [i_id, i_im_id, i_name[0:24], i_price, i_data]
-                line = '\t'.join([str(v) for v in row]) + '\n'
-                f.write(line)
-
-            f.seek(SEEK_SET)
-            conn.cursor.copy_from(f, 'item', null='None')
-
-    def _load_order_line(self, order_line_infos):
         print(f'Loading order_line ({self.warehouse_id})')
         with DBConn(self.dsn) as conn:
-            for d_id in range(1, DIST_PER_WARE + 1):
-                f = StringIO()
-                for o_id in range(1, NUM_ORDERS):
-                    order_line_count, entry_date = order_line_infos[(d_id - 1) * NUM_ORDERS + o_id -
-                                                                    1]
-                    for ol_id in range(1, order_line_count + 1):
-                        row = [
-                                o_id, d_id, self.warehouse_id, ol_id,
-                                self.random.randint_inclusive(1, MAXITEMS), self.warehouse_id,
-                                entry_date if o_id < 2101 else None, 5,
-                                0 if o_id < 2101 else self.random.sample() * 9999.99,
-                                self.tpcc_text.string(24)
-                        ]
-                        f.write('\t'.join([str(v) for v in row]) + '\n')
+            it = StringIteratorIO((
+                self.generate_order_lines(d_id, o_id)
+                for d_id in range(1, DIST_PER_WARE + 1)
+                for o_id in range(1, NUM_ORDERS)
+            ))
+            conn.cursor.copy_from(it, 'order_line', null='None', size=COPY_SIZE)
 
-                f.seek(SEEK_SET)
-                conn.cursor.copy_from(f, 'order_line', null='None')
+    def generate_item(self, i_id):
+        i_im_id = self.random.randint_inclusive(1, 10000)
+        i_price = self.random.sample() * 100 + 1
 
-    def load_orders(self):
-        order_line_infos = self._load_orders_impl()
-        self._load_order_line(order_line_infos)
+        i_name_suffix = self.tpcc_text.string(5)
+        i_name = f'item-{i_im_id}-{i_price}-{i_name_suffix}'
 
-    def load_region(self):
-        print(f'Loading region ({self.warehouse_id})')
+        if self.random.decision(1 / 10):
+            i_data = self.tpcc_text.data_original(26, 50)
+        else:
+            i_data = self.tpcc_text.data(26, 50)
+
+        return self.row_for_copy([i_id, i_im_id, i_name[0:24], i_price, i_data])
+
+    def load_item(self):
+        print(f'Loading items')
+        assert self.warehouse_id == 0
         with DBConn(self.dsn) as conn:
-            f = StringIO()
-            for i in range(NUM_REGIONS):
-                region_key, name = REGIONS[i]
-                row = [region_key, name, self.tpch_text.random_length_text(31, 115)]
-                f.write('\t'.join([str(v) for v in row]) + '\n')
+            it = StringIteratorIO((
+                self.generate_item(i_id)
+                for i_id in range(1, MAXITEMS + 1)
+            ))
+            conn.cursor.copy_from(it, 'item', null='None', size=COPY_SIZE)
 
-            f.seek(SEEK_SET)
-            conn.cursor.copy_from(f, 'region', null='None')
+    def generate_supplier(self, su_id):
+        nation_key = ord(self.tpcc_text.alnumstring(1))
+        if (su_id + 7) % 1893 == 0:
+            comment = self.tpch_text.random_customer_text(25, 100, 'Complaints')
+        elif (su_id + 13) % 1893 == 0:
+            comment = self.tpch_text.random_customer_text(25, 100, 'Recommends')
+        else:
+            comment = self.tpch_text.random_length_text(25, 100)
 
-    def load_nation(self):
-        print(f'Loading nation ({self.warehouse_id})')
-        with DBConn(self.dsn) as conn:
-            f = StringIO()
-            for i in range(NUM_NATIONS):
-                nation_key, name, region_key = NATIONS[i]
-                row = [nation_key, name, region_key, self.tpch_text.random_length_text(31, 114)]
-                f.write('\t'.join([str(v) for v in row]) + '\n')
-
-            f.seek(SEEK_SET)
-            conn.cursor.copy_from(f, 'nation', null='None')
+        return self.row_for_copy([
+            su_id, 'supplier-{:09d}'.format(su_id),
+            self.tpcc_text.string(self.random.randint_inclusive(2, 32), prefix='address-'),
+            nation_key, self.tpch_text.random_phone_number(su_id),
+            self.random.randint_inclusive(-99999, 999999) / 100, comment
+        ])
 
     def load_supplier(self):
-        print(f'Loading supplier ({self.warehouse_id})')
+        print(f'Loading suppliers')
+        assert self.warehouse_id == 0
         with DBConn(self.dsn) as conn:
-            f = StringIO()
-            for su_id in range(NUM_SUPPLIERS):
-                nation_key = ord(self.tpcc_text.alnumstring(1))
-                if (su_id + 7) % 1893 == 0:
-                    comment = self.tpch_text.random_customer_text(25, 100, 'Complaints')
-                elif (su_id + 13) % 1893 == 0:
-                    comment = self.tpch_text.random_customer_text(25, 100, 'Recommends')
-                else:
-                    comment = self.tpch_text.random_length_text(25, 100)
-
-                row = [
-                        su_id, 'supplier-{:09d}'.format(su_id),
-                        self.tpcc_text.string(
-                                self.random.randint_inclusive(2, 32), prefix='address-'
-                        ), nation_key,
-                        self.tpch_text.random_phone_number(su_id),
-                        self.random.randint_inclusive(-99999, 999999) / 100, comment
-                ]
-                f.write('\t'.join([str(v) for v in row]) + '\n')
-
-            f.seek(SEEK_SET)
-            conn.cursor.copy_from(f, 'supplier', null='None')
+            it = StringIteratorIO((
+                self.generate_supplier(su_id)
+                for su_id in range(NUM_SUPPLIERS)
+            ))
+            conn.cursor.copy_from(it, 'supplier', null='None', size=COPY_SIZE)
 
 
 def load_warehouse(dsn, warehouse_id, scale_factor, start_date):

--- a/benchmarks/htap/lib/helpers.py
+++ b/benchmarks/htap/lib/helpers.py
@@ -3,6 +3,8 @@ import random
 
 from contextlib import AbstractContextManager
 from dateutil.parser import isoparse
+from typing import Iterator, Optional
+import io
 
 ALPHA_LOWER = list('abcdefghijklmnopqrstuvwxyz')
 
@@ -321,3 +323,39 @@ class nullcontext(AbstractContextManager):
 
     def __exit__(self, *excinfo):
         pass
+
+# from https://hakibenita.com/fast-load-data-python-postgresql
+class StringIteratorIO(io.TextIOBase):
+    def __init__(self, iter: Iterator[str]):
+        self._iter = iter
+        self._buff = ''
+
+    def readable(self) -> bool:
+        return True
+
+    def _read1(self, n: Optional[int] = None) -> str:
+        while not self._buff:
+            try:
+                self._buff = next(self._iter)
+            except StopIteration:
+                break
+        ret = self._buff[:n]
+        self._buff = self._buff[len(ret):]
+        return ret
+
+    def read(self, n: Optional[int] = None) -> str:
+        line = []
+        if n is None or n < 0:
+            while True:
+                m = self._read1()
+                if not m:
+                    break
+                line.append(m)
+        else:
+            while n > 0:
+                m = self._read1(n)
+                if not m:
+                    break
+                n -= len(m)
+                line.append(m)
+        return ''.join(line)

--- a/benchmarks/htap/lib/transactions.py
+++ b/benchmarks/htap/lib/transactions.py
@@ -16,6 +16,7 @@ class Transactions:
         self.random = Random(seed)
         self.tpcc_text = TPCCText(self.random)
         self.scale_factor = scale_factor
+        print(f"Starting at {initial_timestamp}")
         self.timestamp_generator = TimestampGenerator(
                 initial_timestamp, self.scale_factor, self.random
         )

--- a/benchmarks/htap/prepare.py
+++ b/benchmarks/htap/prepare.py
@@ -7,8 +7,8 @@ from benchmarks.htap import htap_loader as loader
 
 
 class PrepareBenchmark(PrepareBenchmarkFactory):
-    PrepareBenchmarkFactory.PYTHON_LOADER = False
-    PrepareBenchmarkFactory.DO_SHUFFLE = False
+    PrepareBenchmarkFactory.PYTHON_LOADER = True
+    PrepareBenchmarkFactory.DO_SHUFFLE = True
 
     PrepareBenchmarkFactory.TABLES = (TableGroup(
         'warehouse',
@@ -29,19 +29,10 @@ class PrepareBenchmark(PrepareBenchmarkFactory):
         'warehouse',
     ),)
 
-    def get_copy_cmds(self, table):
-        copy_cmd = self.psql_exec_cmd(f'COPY {table} FROM STDIN CSV')
-        if table in ('history', 'order_line', 'orders'):
-            full_path = os.path.join(self.args.data_dir, f'{table}*.gz')
-            return [f'gunzip -c {data_file} | {copy_cmd}' for data_file in glob(full_path)]
-        else:
-            data_file = os.path.join(self.args.data_dir, f'{table}.csv')
-            return [f'cat {data_file} | {copy_cmd}']
-
     def get_ingest_tasks(self, table):
         data_dir = self.args.data_dir
         if data_dir:
-            return self.get_copy_cmds(table)
+            raise ValueError("Cannot use data dir with htap as this doesn't work with the process executor")
 
         else:
             dsn = self.args.dsn


### PR DESCRIPTION
- use the pool executor again so that we can ingest relatively fast
- use a string buffer with a limited size so that we do not pregenerate everything and only then start filling the table as this explodes memory usage with bigger scale-factors