### PR TITLE
correct timestamps and data volume

### DIFF
--- a/benchmarks/htap/htap_loader.py
+++ b/benchmarks/htap/htap_loader.py
@@ -6,29 +6,22 @@ from psycopg2.extras import execute_values
 from s64da_benchmark_toolkit.dbconn import DBConn
 
 from benchmarks.htap.lib.helpers import (
-        Random, TPCCText, TPCHText, NATIONS, REGIONS, TimestampGenerator, StringIteratorIO
+        Random, TPCCText, TPCHText, NATIONS, REGIONS, TimestampGenerator, StringIteratorIO,
+        DIST_PER_WARE, CUST_PER_DIST, NUM_ORDERS, MAXITEMS, STOCKS,
+        NUM_SUPPLIERS, NUM_NATIONS, NUM_REGIONS
 )
-
-MAXITEMS = 100000
-DIST_PER_WARE = 10
-CUST_PER_DIST = 30000 // DIST_PER_WARE
-NUM_ORDERS = 3000
-STOCKS = 100000
-NUM_SUPPLIERS = 10000
-NUM_NATIONS = 62
-NUM_REGIONS = 5
 
 COPY_SIZE=16384
 
 class TPCCLoader():
-    def __init__(self, dsn, warehouse_id, scale_factor, start_date=None):
+    def __init__(self, dsn, warehouse_id = 0, start_date=None):
         self.dsn = dsn
         self.warehouse_id = warehouse_id
         self.random = Random(seed=warehouse_id)
         self.tpcc_text = TPCCText(self.random)
         self.tpch_text = TPCHText(self.random)
         self.start_date = start_date or datetime.now()
-        self.timestamp_generator = TimestampGenerator(self.start_date, scale_factor, self.random)
+        self.timestamp_generator = TimestampGenerator(self.start_date, self.random)
 
     def insert_data(self, table, data):
         with DBConn(self.dsn) as conn:
@@ -278,8 +271,8 @@ class TPCCLoader():
             conn.cursor.copy_from(it, 'supplier', null='None', size=COPY_SIZE)
 
 
-def load_warehouse(dsn, warehouse_id, scale_factor, start_date):
-    loader = TPCCLoader(dsn, warehouse_id, scale_factor, start_date)
+def load_warehouse(dsn, warehouse_id, start_date):
+    loader = TPCCLoader(dsn, warehouse_id, start_date)
     loader.load_customer()
     loader.load_district()
     loader.load_history()
@@ -288,21 +281,21 @@ def load_warehouse(dsn, warehouse_id, scale_factor, start_date):
     loader.load_warehouse()
 
 
-def load_item(dsn, scale_factor):
-    loader = TPCCLoader(dsn, 0, scale_factor)
+def load_item(dsn):
+    loader = TPCCLoader(dsn)
     loader.load_item()
 
 
-def load_region(dsn, scale_factor):
-    loader = TPCCLoader(dsn, 0, scale_factor)
+def load_region(dsn):
+    loader = TPCCLoader(dsn)
     loader.load_region()
 
 
-def load_nation(dsn, scale_factor):
-    loader = TPCCLoader(dsn, 0, scale_factor)
+def load_nation(dsn):
+    loader = TPCCLoader(dsn)
     loader.load_nation()
 
 
-def load_supplier(dsn, scale_factor):
-    loader = TPCCLoader(dsn, 0, scale_factor)
+def load_supplier(dsn):
+    loader = TPCCLoader(dsn)
     loader.load_supplier()

--- a/benchmarks/htap/lib/helpers.py
+++ b/benchmarks/htap/lib/helpers.py
@@ -6,6 +6,20 @@ from dateutil.parser import isoparse
 from typing import Iterator, Optional
 import io
 
+# see section 4.2.2.12, page 81 of http://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.2.pdf
+TPCH_DATE_RANGE = [isoparse('1992-01-01'), isoparse('1998-12-31')]
+
+# see http://www.tpc.org/tpc_documents_current_versions/pdf/tpc-c_v5.11.0.pdf page 62
+DIST_PER_WARE = 10
+CUST_PER_DIST = 30000
+NUM_ORDERS = 30000
+MAXITEMS = 100000
+STOCKS = 100000
+# tpch constants
+NUM_SUPPLIERS = 10000
+NUM_NATIONS = 62
+NUM_REGIONS = 5
+
 ALPHA_LOWER = list('abcdefghijklmnopqrstuvwxyz')
 
 ALPHA_UPPER = list('ABCDEFGHIJKLMNOPQRSTUVWXYZ')
@@ -284,21 +298,13 @@ class TPCHText:
 
 
 class TimestampGenerator:
-    def __init__(self, start_date, scale_factor, random):
+    def __init__(self, start_date, random, scalar = 1.0):
         self.random = random
         self.current = start_date
-        self.increment = self.timestamp_distance(scale_factor)
 
-    @staticmethod
-    def timestamp_distance(scale_factor):
-        tpch_num_orders_per_sf = 1500000
-        tpch_data_duration = isoparse('1998-08-02') - isoparse('1992-01-01')
-        tpcc_inverse_order_frac = 1 / 0.44
-        seconds_per_transaction = (
-                tpch_data_duration / (tpcc_inverse_order_frac * tpch_num_orders_per_sf)
-        )
-
-        return seconds_per_transaction / scale_factor
+        orders_per_warehouse = NUM_ORDERS * DIST_PER_WARE
+        date_range = TPCH_DATE_RANGE[1] - TPCH_DATE_RANGE[0]
+        self.increment = (date_range / orders_per_warehouse) * scalar
 
     def next(self):
         self.current += self.increment * self.random.gaussian(mean=1, variance=0.05)

--- a/benchmarks/htap/lib/queries.py
+++ b/benchmarks/htap/lib/queries.py
@@ -10,6 +10,7 @@ import psycopg2
 import yaml
 
 from .helpers import Random
+from .helpers import TPCH_DATE_RANGE
 
 
 TEMPLATE_DIR = path.join('benchmarks', 'htap', 'queries')
@@ -55,10 +56,8 @@ class Queries:
 
     @staticmethod
     def tpch_date_to_benchmark_date(tpch_date, min_date, max_date):
-        tpch_lowest_delivery_date = isoparse('1992-01-01')
-        tpch_highest_delivery_date = isoparse('1998-12-31')
-        tpch_delta = tpch_date - tpch_lowest_delivery_date
-        tpch_total = tpch_highest_delivery_date - tpch_lowest_delivery_date
+        tpch_delta = tpch_date - TPCH_DATE_RANGE[0]
+        tpch_total = TPCH_DATE_RANGE[1] - TPCH_DATE_RANGE[0]
         tpch_fraction = tpch_delta / tpch_total
         benchmark_delta = max_date - min_date
         benchmark_start = min_date + benchmark_delta * tpch_fraction

--- a/benchmarks/htap/prepare.py
+++ b/benchmarks/htap/prepare.py
@@ -40,10 +40,10 @@ class PrepareBenchmark(PrepareBenchmarkFactory):
             if table in ['item', 'region', 'nation', 'supplier']:
                 func_name = 'load_{}'.format(table)
                 func = getattr(loader, func_name)
-                return [(func, dsn, self.args.scale_factor)]
+                return [(func, dsn)]
             elif table == 'warehouse':
                 warehouses = range(1, self.args.scale_factor + 1)
-                return [(loader.load_warehouse, dsn, w_id, self.args.scale_factor, start_date)
+                return [(loader.load_warehouse, dsn, w_id, start_date)
                         for w_id in warehouses]
 
             raise ValueError(f'Unknown table {table}')

--- a/benchmarks/htap/tests/test_helpers.py
+++ b/benchmarks/htap/tests/test_helpers.py
@@ -29,12 +29,3 @@ def test_tpcc_text():
     assert all([is_alpha(c) or c.isdigit() for c in fixture.alnumstring(100)])
     assert all([is_alpha(c) or is_special(c) or c.isdigit() for c in fixture.alnum64string(100)])
     assert 'ORIGINAL' in fixture.data_original(0, 100)
-
-
-def test_timestamp_distance():
-    expected_distance = (isoparse('1998-08-02') - isoparse('1992-01-01')) * (0.44 / 1500000)
-
-    assert TimestampGenerator.timestamp_distance(scale_factor=1) == expected_distance
-    assert TimestampGenerator.timestamp_distance(scale_factor=10) == expected_distance / 10
-    assert TimestampGenerator.timestamp_distance(scale_factor=100) == expected_distance / 100
-    assert TimestampGenerator.timestamp_distance(scale_factor=1000) == expected_distance / 1000


### PR DESCRIPTION
- correctly size num_orders (30K instead of 3K)
- fix the timestamp increments used by differentiating properly between ignest and run.
  now we get the same timestamp range irrespective of the number of warehouses used.
- remove some unneeded code and parameters
- temporarily disable gaussian noise until we also have a shared-memory timestamp increase