### PR TITLE
htap benchmark changes to evaluate columnstore improvements

### DIFF
--- a/benchmarks/htap/__init__.py
+++ b/benchmarks/htap/__init__.py
@@ -4,20 +4,28 @@ from benchmarks.htap.lib.controller import HTAPController
 def add_parser(subparsers):
     parser = subparsers.add_parser('htap')
     parser.add_argument(
-        '--oltp-workers', default=1, type=int, help=(
-        'The number of OLTP workers executing TPC-C transactions (i.e. simulated clients).'))
+        '--oltp-workers', default=32, type=int, help=(
+        'The number of OLTP workers executing TPC-C transactions (i.e. simulated clients), default: 32.'))
 
     parser.add_argument(
         '--olap-workers', default=1, type=int, help=(
-        'The number of OLAP workers running TPC-H-like queries.'))
+        'The number of OLAP workers running TPC-H-like queries, default: 1.'))
+
+    parser.add_argument(
+        '--target-tps', default=None, type=int, help=(
+        'The target TPS for the otlp queries, default: unlimited.'))
 
     parser.add_argument(
         '--duration', default=60, type=int, help=(
-        'How many seconds the benchmark should run for.'))
+        'How many seconds the benchmark should run for, default: 60.'))
 
     parser.add_argument(
         '--olap-timeout', default=900, type=int, help=(
         'Timeout for OLAP queries in seconds, default: 900'))
+
+    parser.add_argument(
+        '--tpcc-csv-interval', default=60, type=int, help=(
+        'How often to report tpcc stats to the csv file in seconds, default: 60'))
 
     parser.add_argument(
         '--dry-run', action='store_true', help=(
@@ -25,13 +33,20 @@ def add_parser(subparsers):
         "Can be useful for measuring script throughput."))
 
     parser.add_argument(
-        '--monitoring-interval', default=1, type=int, help=(
-        'Number of seconds to wait between updates of the monitoring display, default: 1'))
+        '--monitoring-interval', default=1, type=float, help=(
+        'Number of seconds to wait between updates of the monitoring display, default: 1.0'))
 
     parser.add_argument(
         '--stats-dsn', help=('The DSN to use for collecting statistics into a database. '
         'Not defining it will disable statistics collection.'))
 
+    parser.add_argument('--explain-analyze', action='store_true', default=False,
+            help=('Whether to run EXPLAIN ANALYZE. Will save plans into the "plan" directory.'
+        ))
+
+    parser.add_argument('--use-server-side-cursors', default=False, action='store_true',
+        required=False, help=('Use server-side cursors for executing the queries')
+    )
 
 def run(args):
     controller = HTAPController(args)

--- a/benchmarks/htap/queries/01.sql.template
+++ b/benchmarks/htap/queries/01.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     ol_number,
     sum(ol_quantity) as sum_qty,
@@ -8,7 +9,8 @@ select
     count(*) as count_order
 from
     order_line
-    where ol_delivery_d > '$date'
+where
+    ol_delivery_d > '$date'
 group by
     ol_number
 order by

--- a/benchmarks/htap/queries/02.sql.template
+++ b/benchmarks/htap/queries/02.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     su_suppkey,
     su_name,

--- a/benchmarks/htap/queries/03.sql.template
+++ b/benchmarks/htap/queries/03.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     ol_o_id,
     ol_w_id,
@@ -21,6 +22,7 @@ where c_state like 'A%'
     and ol_d_id = o_d_id
     and ol_o_id = o_id
     and o_entry_d > '$date'
+    and ol_delivery_d >= '$min_date'
 group by
     ol_o_id,
     ol_w_id,

--- a/benchmarks/htap/queries/04.sql.template
+++ b/benchmarks/htap/queries/04.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     o_ol_cnt,
     count(*) as order_count
@@ -17,6 +18,7 @@ where
             and o_w_id = ol_w_id
             and o_d_id = ol_d_id
             and ol_delivery_d >= o_entry_d
+            and ol_delivery_d >= '$min_date'
     )
 group by
     o_ol_cnt

--- a/benchmarks/htap/queries/05.sql.template
+++ b/benchmarks/htap/queries/05.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     n_name,
     sum(ol_amount) as revenue
@@ -26,6 +27,7 @@ where
     and r_name = 'Europe'
     and o_entry_d >= '$begin_date'
     and o_entry_d < '$end_date'
+    and ol_delivery_d >= '$min_date'
 group by
     n_name
 order by

--- a/benchmarks/htap/queries/06.sql.template
+++ b/benchmarks/htap/queries/06.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     sum(ol_amount) as revenue
 from

--- a/benchmarks/htap/queries/07.sql.template
+++ b/benchmarks/htap/queries/07.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     su_nationkey as supp_nation,
     substr(c_state, 1, 1) as cust_nation,
@@ -30,6 +31,7 @@ where
         (n1.n_name = 'Cambodia' and n2.n_name = 'Germany')
     )
     and ol_delivery_d between '$begin_date' and '$end_date'
+    and o_entry_d >= '$min_date'
 group by
     su_nationkey,
     substr(c_state, 1, 1),

--- a/benchmarks/htap/queries/08.sql.template
+++ b/benchmarks/htap/queries/08.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     extract(year from o_entry_d) as l_year,
     sum(case when n2.n_name = 'Germany' then ol_amount else 0 end)
@@ -32,6 +33,7 @@ where
     and o_entry_d between '$begin_date' and '$end_date'
     and i_data like '%b'
     and i_id = ol_i_id
+    and ol_delivery_d >= '$min_date'
 group by
     extract(year from o_entry_d)
 order by

--- a/benchmarks/htap/queries/09.sql.template
+++ b/benchmarks/htap/queries/09.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     n_name,
     extract(year from o_entry_d) as l_year,
@@ -20,6 +21,8 @@ where
     and ol_i_id = i_id
     and su_nationkey = n_nationkey
     and i_data like '%BB'
+    and ol_delivery_d >= '$min_date'
+    and o_entry_d >= '$min_date'
 group by
     n_name,
     extract(year from o_entry_d)

--- a/benchmarks/htap/queries/10.sql.template
+++ b/benchmarks/htap/queries/10.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     c_id,
     c_last,
@@ -22,6 +23,7 @@ where
     and o_entry_d < '$end_date'
     and o_entry_d <= ol_delivery_d
     and n_nationkey = ascii(substr(c_state, 1, 1))
+    and ol_delivery_d >= '$min_date'
 group by
     c_id,
     c_last,

--- a/benchmarks/htap/queries/11.sql.template
+++ b/benchmarks/htap/queries/11.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     s_i_id,
     sum(s_order_cnt) as order_count

--- a/benchmarks/htap/queries/12.sql.template
+++ b/benchmarks/htap/queries/12.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     o_ol_cnt,
     sum(case when o_carrier_id = 1 or o_carrier_id = 2 then 1 else 0 end)
@@ -15,6 +16,7 @@ where
     and o_entry_d <= ol_delivery_d
     and ol_delivery_d >= '$begin_date'
     and ol_delivery_d < '$end_date'
+    and o_entry_d >= '$min_date'
 group by
     o_ol_cnt
 order by

--- a/benchmarks/htap/queries/13.sql.template
+++ b/benchmarks/htap/queries/13.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     c_count,
     count(*) as custdist

--- a/benchmarks/htap/queries/14.sql.template
+++ b/benchmarks/htap/queries/14.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     100.00 * sum(case when i_data like 'PR%' then ol_amount else 0 end)
         / (1 + sum(ol_amount)) as promo_revenue

--- a/benchmarks/htap/queries/15.sql.template
+++ b/benchmarks/htap/queries/15.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 with revenue (supplier_no, total_revenue) as (
     select
         mod((s_w_id * s_i_id), 10000) as supplier_no,

--- a/benchmarks/htap/queries/16.sql.template
+++ b/benchmarks/htap/queries/16.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     i_name,
     substr(i_data, 1, 3) as brand,

--- a/benchmarks/htap/queries/17.sql.template
+++ b/benchmarks/htap/queries/17.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     sum(ol_amount) / 2.0 as avg_yearly
 from
@@ -11,8 +12,10 @@ from
         where
             i_data like '%b'
             and ol_i_id = i_id
+            and ol_delivery_d >= '$min_date'
         group by
             i_id) t
 where
     ol_i_id = t.i_id
-    and ol_quantity < t.a;
+    and ol_quantity < t.a
+    and ol_delivery_d >= '$min_date';

--- a/benchmarks/htap/queries/18.sql.template
+++ b/benchmarks/htap/queries/18.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     c_last,
     c_id o_id,
@@ -14,6 +15,8 @@ where
     and ol_w_id = o_w_id
     and ol_d_id = o_d_id
     and ol_o_id = o_id
+    and o_entry_d >= '$min_date'
+    and ol_delivery_d >= '$min_date'
 group by
     o_id,
     o_w_id,

--- a/benchmarks/htap/queries/19.sql.template
+++ b/benchmarks/htap/queries/19.sql.template
@@ -1,10 +1,14 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     sum(ol_amount) as revenue
 from
     order_line,
     item
-where (
+where
+    ol_delivery_d >= '$min_date'
+    and
+    (
         ol_i_id = i_id
         and i_data like '%a'
         and ol_quantity >= 1

--- a/benchmarks/htap/queries/20.sql.template
+++ b/benchmarks/htap/queries/20.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     su_name,
     su_address

--- a/benchmarks/htap/queries/21.sql.template
+++ b/benchmarks/htap/queries/21.sql.template
@@ -1,4 +1,5 @@
 -- vim: set ft=sql:
+-- EXPLAIN (FORMAT JSON)
 select
     su_name, count(*) as numwait
 from
@@ -24,9 +25,12 @@ where
             and l2.ol_w_id = l1.ol_w_id
             and l2.ol_d_id = l1.ol_d_id
             and l2.ol_delivery_d > l1.ol_delivery_d
+            and l2.ol_delivery_d >= '$min_date'
     )
     and su_nationkey = n_nationkey
     and n_name = 'Cambodia'
+    and o_entry_d >= '$min_date'
+    and l1.ol_delivery_d >= '$min_date'
 group by
     su_name
 order by

--- a/benchmarks/htap/queries/22.sql.template
+++ b/benchmarks/htap/queries/22.sql.template
@@ -1,6 +1,7 @@
 -- vim: set ft=sql:
 -- FIXME: This query produces an empty result as there are
 -- no customers who never ordered.
+-- EXPLAIN (FORMAT JSON)
 select
     substr(c_state, 1, 1) as country,
     count(*) as numcust,
@@ -8,15 +9,16 @@ select
 from
     customer
 where
-    substr(c_phone, 1, 1) in ('1', '2', '3', '4', '5', '6', '7')
+    substring(c_phone from 1 for 2) in ('32', '27', '31', '25', '26', '24', '19')
     and c_balance > (
+
         select
             avg(c_balance)
         from
             customer
         where
             c_balance > 0.00
-            and substr(c_phone, 1, 1) in ('1', '2', '3', '4', '5', '6', '7')
+            and substring(c_phone from 1 for 2) in ('32', '27', '31', '25', '26', '24', '19')
     )
     and not exists (
         select
@@ -27,6 +29,7 @@ where
             o_c_id = c_id
             and o_w_id = c_w_id
             and o_d_id = c_d_id
+            and o_entry_d >= '$min_date'
     )
 group by
     substr(c_state, 1, 1)

--- a/benchmarks/htap/schemas/s64da_native_enhanced/s64da_indexes.sql
+++ b/benchmarks/htap/schemas/s64da_native_enhanced/s64da_indexes.sql
@@ -46,33 +46,34 @@ CREATE INDEX idx_order_line_cache ON order_line USING columnstore (
   , ol_dist_info
 );
 
-CREATE INDEX idx_item_cache ON item USING columnstore (
-    i_id
-  , i_im_id
-  , i_name
-  , i_price
-  , i_data
+CREATE INDEX idx_stock_cache ON stock USING columnstore (
+    s_i_id
+  , s_w_id
+  , s_quantity
+  , s_dist_01
+  , s_dist_02
+  , s_dist_03
+  , s_dist_04
+  , s_dist_05
+  , s_dist_06
+  , s_dist_07
+  , s_dist_08
+  , s_dist_09
+  , s_dist_10
+  , s_ytd
+  , s_order_cnt
+  , s_remote_cnt
+  , s_data
 );
 
-CREATE INDEX idx_region_cache ON region USING columnstore (
-    r_regionkey
-  , r_name
-  , r_comment
-);
-
-CREATE INDEX idx_nation_cache ON nation USING columnstore (
-    n_nationkey
-  , n_name
-  , n_regionkey
-  , n_comment
-);
-
-CREATE INDEX idx_supplier_cache ON supplier USING columnstore (
-    su_suppkey
-  , su_name
-  , su_address
-  , su_nationkey
-  , su_phone
-  , su_acctbal
-  , su_comment
+CREATE INDEX idx_history_cache ON history USING columnstore (
+    id
+  , h_c_id
+  , h_c_d_id
+  , h_c_w_id
+  , h_d_id
+  , h_w_id
+  , h_date
+  , h_amount
+  , h_data
 );

--- a/benchmarks/htap/tests/test_queries.py
+++ b/benchmarks/htap/tests/test_queries.py
@@ -3,20 +3,17 @@ import pytest
 from datetime import datetime
 from dateutil.parser import isoparse
 
+from benchmarks.htap.lib.helpers import TPCH_DATE_RANGE
 from benchmarks.htap.lib.queries import Queries
 
+class DateValue:
+    value = isoparse('2198-12-31').timestamp()
 
 def test_tpch_date_to_benchmark_date():
-    tpch_min_date = isoparse('1992-01-01')
-    tpch_max_date = isoparse('1998-12-31')
+    queries = Queries(0, {}, None, DateValue(), None)
 
-    # date ranges that are in the same range should get the same result
-    date1 = isoparse('1993-01-01')
-    date2 = isoparse('1995-01-01')
-    date3 = isoparse('2011-04-05')
-    date4 = isoparse('1900-03-06')
-    assert Queries.tpch_date_to_benchmark_date(date1, tpch_min_date, tpch_max_date) == date1
-    assert Queries.tpch_date_to_benchmark_date(date2, tpch_min_date, tpch_max_date) == date2
-    assert Queries.tpch_date_to_benchmark_date(date3, tpch_min_date, tpch_max_date) == date3
-    assert Queries.tpch_date_to_benchmark_date(date4, tpch_min_date, tpch_max_date) == date4
+    assert queries.tpch_date_to_benchmark_date(isoparse('1993-01-01')) == isoparse('2193-01-01')
+    assert queries.tpch_date_to_benchmark_date(isoparse('1995-01-01')) == isoparse('2195-01-01')
+    assert queries.tpch_date_to_benchmark_date(isoparse('2211-01-01')) == isoparse('2411-01-01')
+    assert queries.tpch_date_to_benchmark_date(isoparse('1801-01-01')) == isoparse('2001-01-01')
 

--- a/prepare_benchmark
+++ b/prepare_benchmark
@@ -84,7 +84,7 @@ if __name__ == '__main__':
     ))
 
     args_to_parse.add_argument(
-        '--start-date', default=None, type=parser.isoparse, help=(
+        '--start-date', default='1992-01-01', type=parser.isoparse, help=(
         'The start date for TPC-C.'
     ))
 

--- a/s64da_benchmark_toolkit/db.py
+++ b/s64da_benchmark_toolkit/db.py
@@ -70,7 +70,14 @@ class DB:
                 else:
                     query_result = None
                 status = Status.OK
-                plan = '\n'.join(conn.conn.notices)
+                # each notice can take multiple lines; we just want all lines separately
+                # so we can filter easily as we don't want the lines that have "LOG:" in them
+                # but only want the real json output
+                notice_lines = '\n'.join(conn.conn.notices).split('\n')
+                plan = '\n'.join(filter(lambda line: not line.startswith("LOG:"), notice_lines))
+                # make it proper json
+                if plan.strip() != '':
+                    plan = f'[{plan}]'
 
             except psycopg2.extensions.QueryCanceledError:
                 status = Status.TIMEOUT

--- a/s64da_benchmark_toolkit/dbconn.py
+++ b/s64da_benchmark_toolkit/dbconn.py
@@ -3,13 +3,13 @@ import logging
 import time
 
 import psycopg2
-
+from psycopg2.extras import DictCursor
 
 LOG = logging.getLogger()
 
 
 class DBConn:
-    def __init__(self, dsn, statement_timeout=0, num_retries=120, retry_wait=1):
+    def __init__(self, dsn, statement_timeout=0, num_retries=120, retry_wait=1, use_dict_cursor = False):
         self.dsn = dsn
         self.conn = None
         self.cursor = None
@@ -17,6 +17,7 @@ class DBConn:
         self.statement_timeout = statement_timeout
         self.num_retries = num_retries
         self.retry_wait = retry_wait
+        self.use_dict_cursor = use_dict_cursor
 
     def __enter__(self):
         options = f'-c statement_timeout={self.statement_timeout}'
@@ -25,7 +26,7 @@ class DBConn:
             try:
                 self.conn = psycopg2.connect(self.dsn, options=options)
                 self.conn.autocommit = True
-                self.cursor = self.conn.cursor()
+                self.cursor = self.conn.cursor(cursor_factory = DictCursor if self.use_dict_cursor else None)
                 self.server_side_cursor = self.conn.cursor('server-side-cursor')
                 break
 


### PR DESCRIPTION
    - introduce target TPS
    - introduce global timestamp generation
    - add oltp stats about latency & TPS per query type
    - add stats about columnstore effectiveness
    - make timestamp generation uniform between ingest and benchmark
    - olap workers now select a fixed amount of data
    - olap workers wait until enough data is available before they start running queries
    - improve monitor display to include:
      - tps
      - timeouts
      - data range so far ingested
      - planned & processed row counts
      - displaying only certain parts (like e.g. only oltp output if there's no olap workers)
    - add support for explain-analyze
    - support writing out plans
    - add support for server side cursors
    - always output proper json for explain output
    - add support for writing out statistics to csv, for tpcc and tpch separately
    - improve olap monitor view
    
    - make some constants into variables
    - fix rowcount for history table
    - fix date generation order for orders and order lines to be relative to order and not district
    - add a delivery date offset to the order lines on ingestion
    - use correct values from helpers.py in transactions.py
    - use the official methods to propagate errors from forks to the parent of
      the multiprocess pool: wait() and get()
    - rework controller to use simpler datatypes so that we can use synchronized
      timstamp generation somewhat easily
    - simplify controller by making the worker functions part of the class
    - remove unused code (e.g. latest timestamp from statistics)
    - correct again rowcounts for certain tables
    - remove columnstores on very small tables (<8MB)