### PR TITLE
Report OLAP stream stats

### DIFF
--- a/benchmarks/htap/lib/monitoring.py
+++ b/benchmarks/htap/lib/monitoring.py
@@ -51,13 +51,17 @@ class Monitor:
         print(tabulate(rows, headers=['', 'Average transactions per second',  'Average latency (ms)']))
 
         print('')
+        print(f'OLAP')
+        rows = []
+        avg_stream_runtime, n_streams = self.stats.olap_stream_totals()
+        rows.append(['Average stream runtime (ms)', avg_stream_runtime])
+        rows.append(['Completed stream iterations', n_streams])
         num_ok, num_errors, num_timeouts = self.stats.olap_totals()
-        print(f'OLAP Queries')
-        print(f'Completed: {num_ok:}')
-        print(f'Errors: {num_errors:}')
-        print(f'Timeouts: {num_timeouts:}')
+        rows.append(['Succesful queries', num_ok])
+        rows.append(['Queries with errors', num_errors])
+        rows.append(['Query timeouts', num_timeouts])
+        print(tabulate(rows))
         # TODO output average query runtime per query type
-        # TODO output average stream runtime
 
     def get_elapsed_row(self, elapsed_seconds):
         unit = 'second' if elapsed_seconds < 2 else 'seconds'

--- a/benchmarks/htap/tests/test_stats.py
+++ b/benchmarks/htap/tests/test_stats.py
@@ -172,3 +172,22 @@ def test_olap_totals():
     queue = MockQueue(data)
     fixture.process_queue(queue)
     assert fixture.olap_totals() == (2, 2, 1)
+
+def test_olap_stream_totals():
+    fixture = Stats(dsn, num_oltp_slots=0, num_olap_slots=1, csv_interval=1)
+    queue = MockQueue()
+    fixture.process_queue(queue)
+    assert fixture.olap_stream_totals() == ('-', 0)
+
+    # yapf: disable
+    data = [
+            ('olap_stream', {'stream': 0, 'iteration': 0, 'runtime': '1'}),
+            ('olap_stream', {'stream': 1, 'iteration': 0, 'runtime': '10'}),
+            ('olap_stream', {'stream': 2, 'iteration': 0, 'runtime': '20'}),
+            ('olap_stream', {'stream': 0, 'iteration': 1, 'runtime': '1'}),
+    ]
+    # yapf: enable
+    fixture = Stats(dsn, num_oltp_slots=0, num_olap_slots=3, csv_interval=1)
+    queue = MockQueue(data)
+    fixture.process_queue(queue)
+    assert fixture.olap_stream_totals() == (8, 4)


### PR DESCRIPTION
Report average stream runtime and number of completed stream iterations.
For that the analytical workers report to the collector when they have completed a stream.


PR based on https://github.com/swarm64/s64da-benchmark-toolkit/pull/132