### PR TITLE
Added hint to TPCH Q9: Disable planning optimization

### DIFF
--- a/benchmarks/tpch/queries/9.sql
+++ b/benchmarks/tpch/queries/9.sql
@@ -1,5 +1,6 @@
 -- using 1512813808 as a seed to the RNG
 -- EXPLAIN (FORMAT JSON)
+/*+ Set(swarm64da.enable_fast_num_groups_estimation off) */
 select
     nation,
     o_year,


### PR DESCRIPTION
We need this hint to fix regression on 1T power and throughput tests.